### PR TITLE
[TEC-69] Provision AWS tag policy using Terraform

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,44 @@ terraform destroy -var-file=../../../vars/dev/ec2.tfvars
 
 **Note**: Always review the execution plan (`terraform plan`) before applying changes to avoid unintended modifications.
 
+## Terraform AWS Organization Tag Policy Implement.
+
+1. Navigate to the `environment/dev` folder:
+
+```bash
+cd environment/tag-policy
+```
+
+2. Open the `tag-policy.tfvars` file and modify it with your desired details. This file contains variables used in the Terraform configuration.
+
+## Deployment
+
+1. Initialize Terraform in the working directory:
+
+```bash
+terraform init
+```
+
+2. Create an execution plan:
+
+```bash
+terraform plan -var-file=../../../vars/dev/tag-policy.tfvars
+```
+
+3. Apply the changes to create the Tag Policy:
+
+```bash
+terraform apply -var-file=../../../vars/dev/tag-policy.tfvars
+```
+
+4. To destroy the Tag Policy:
+
+```bash
+terraform destroy -var-file=../../../vars/dev/tag-policy.tfvars
+```
+
+**Note**: Always review the execution plan (`terraform plan`) before applying changes to avoid unintended modifications.
+
 ## Command Reference
 
 Update all outputs:

--- a/README.md
+++ b/README.md
@@ -27,6 +27,44 @@ terraform apply -var-file=../../../vars/dev/rds.tfvars
 
 terraform destroy -var-file=../../../vars/dev/rds.tfvars
 
+## Terraform EC2 Instance Deployment
+
+1. Navigate to the `environment/dev` folder:
+
+```bash
+cd environment/dev
+```
+
+2. Open the `ec2.tfvars` file and modify it with your desired details. This file contains variables used in the Terraform configuration.
+
+## Deployment
+
+1. Initialize Terraform in the working directory:
+
+```bash
+terraform init
+```
+
+2. Create an execution plan:
+
+```bash
+terraform plan -var-file=../../../vars/dev/ec2.tfvars
+```
+
+3. Apply the changes to create the EC2 instance:
+
+```bash
+terraform apply -var-file=../../../vars/dev/ec2.tfvars
+```
+
+4. To destroy the EC2 instance and associated resources:
+
+```bash
+terraform destroy -var-file=../../../vars/dev/ec2.tfvars
+```
+
+**Note**: Always review the execution plan (`terraform plan`) before applying changes to avoid unintended modifications.
+
 ## Command Reference
 
 Update all outputs:
@@ -36,8 +74,6 @@ Update all outputs:
 Show all outputs:
 
 <pre>terraform show</pre>
-
-
 
 
 

--- a/environments/dev/tag-policy/main.tf
+++ b/environments/dev/tag-policy/main.tf
@@ -1,0 +1,11 @@
+provider "aws" {
+  region = var.region
+}
+
+module "tag-policy" {
+  source      = "../../../modules/tag-policy"
+  region      = var.region
+  policy_name = var.policy_name
+  policy_type = var.policy_type
+  target_id   = var.target_id
+}

--- a/environments/dev/tag-policy/outputs.tf
+++ b/environments/dev/tag-policy/outputs.tf
@@ -1,0 +1,4 @@
+output "policy_id" {
+  value       = module.tag-policy.policy_id
+  description = "ID of the tag policy"
+}

--- a/environments/dev/tag-policy/variables.tf
+++ b/environments/dev/tag-policy/variables.tf
@@ -1,0 +1,19 @@
+variable "region" {
+  type        = string
+  description = "Region for the provider"
+}
+
+variable "policy_name" {
+  type        = string
+  description = "Name for the tag policy"
+}
+
+variable "policy_type" {
+  type        = string
+  description = "Type of the policy"
+}
+
+variable "target_id" {
+  type        = number
+  description = "ID of the target"
+}

--- a/modules/tag-policy/main.tf
+++ b/modules/tag-policy/main.tf
@@ -1,0 +1,103 @@
+# Provider Configuration 
+provider "aws" {
+  region = var.region
+}
+
+# Create Tag Policy
+resource "aws_organizations_policy" "tag_policy" {
+  name        = var.policy_name
+  description = "Resource Provision"
+
+  content = jsonencode({
+    "tags" = {
+      "Name" = {
+        "tag_key" = {
+          "@@assign" = "Name"
+        },
+        "enforced_for" = {
+          "@@assign" = [
+            "ec2:instance",
+            "ec2:security-group"
+          ]
+        }
+      },
+      "Environment" = {
+        "tag_key" = {
+          "@@assign" = "Environment"
+        },
+        "tag_value" = {
+          "@@assign" = [
+            "dev",
+            "stage",
+            "prod"
+          ]
+        },
+        "enforced_for" = {
+          "@@assign" = [
+            "ec2:instance",
+            "ec2:security-group"
+          ]
+        }
+      },
+      "Owner" = {
+        "tag_key" = {
+          "@@assign" = "Owner"
+        },
+        "tag_value" = {
+          "@@assign" = [
+            "Techiescamp"
+          ]
+        },
+        "enforced_for" = {
+          "@@assign" = [
+            "ec2:instance",
+            "ec2:security-group"
+          ]
+        }
+      },
+      "CostCenter" = {
+        "tag_key" = {
+          "@@assign" = "CostCenter"
+        },
+        "tag_value" = {
+          "@@assign" = [
+            "project-pet-clinic"
+          ]
+        },
+        "enforced_for" = {
+          "@@assign" = [
+            "ec2:instance",
+            "ec2:security-group"
+          ]
+        }
+      },
+      "Application" = {
+        "tag_key" = {
+          "@@assign" = "Application"
+        },
+        "tag_value" = {
+          "@@assign" = [
+            "web-app"
+          ]
+        },
+        "enforced_for" = {
+          "@@assign" = [
+            "ec2:instance",
+            "ec2:security-group"
+          ]
+        }
+      }
+    }
+  })
+
+  type = var.policy_type
+}
+
+resource "aws_organizations_policy_attachment" "account_attachment" {
+  policy_id = aws_organizations_policy.tag_policy.id
+  target_id = var.target_id
+}
+
+
+
+

--- a/modules/tag-policy/outputs.tf
+++ b/modules/tag-policy/outputs.tf
@@ -1,0 +1,4 @@
+output "policy_id" {
+  value       = aws_organizations_policy.tag_policy.id
+  description = "ID of the tag policy."
+}

--- a/modules/tag-policy/variables.tf
+++ b/modules/tag-policy/variables.tf
@@ -1,0 +1,19 @@
+variable "region" {
+  type        = string
+  description = "Region for the provider."
+}
+
+variable "policy_name" {
+  type        = string
+  description = "Name for the tag policy."
+}
+
+variable "policy_type" {
+  type        = string
+  description = "Type of the policy."
+}
+
+variable "target_id" {
+  type        = number
+  description = "ID of the target."
+}

--- a/vars/dev/tag-policy.tfvars
+++ b/vars/dev/tag-policy.tfvars
@@ -1,0 +1,5 @@
+# Tag Policy Vars
+region      = "eu-north-1"
+policy_name = "Techiescamp"
+policy_type = "TAG_POLICY"
+target_id   = "814200988517"


### PR DESCRIPTION
### Changes Made:

* Created a new Terraform module named tag-policy to handle AWS tag policies more efficiently.
* Implemented an AWS tag policy for EC2 instances, ensuring mandatory tags are set for all instances.
* Enforced an AWS tag policy for security groups, requiring specific tags for each security group created.